### PR TITLE
Bucket filling to thread filling

### DIFF
--- a/images/source/placement_design_data_structure.dot
+++ b/images/source/placement_design_data_structure.dot
@@ -228,8 +228,8 @@ The results of a placement algorithm execution.<BR ALIGN="TEXT"/>
 Does simulated annealing.<BR ALIGN="TEXT"/>
 </TD></TR></TABLE>>];
 
-    BucketFilling[label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
-<TR><TD>BucketFilling:Algorithm</TD></TR>
+    ThreadFilling[label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
+<TR><TD>ThreadFilling:Algorithm</TD></TR>
 <TR><TD ALIGN="TEXT">
 ...<BR ALIGN="TEXT"/>
 </TD></TR>
@@ -237,7 +237,7 @@ Does simulated annealing.<BR ALIGN="TEXT"/>
 ...<BR ALIGN="TEXT"/>
 </TD></TR>
 <TR><TD ALIGN="TEXT">
-Does bucket filling.<BR ALIGN="TEXT"/>
+Does thread filling.<BR ALIGN="TEXT"/>
 </TD></TR></TABLE>>];
 
     /* Relationship definitions (as graph edges) */
@@ -287,8 +287,8 @@ Does bucket filling.<BR ALIGN="TEXT"/>
 
     /* Inheritance */
     {edge[arrowhead="onormal", label=" (inherits)"];
-        //BucketFilling -> Algorithm;
-        Algorithm -> BucketFilling[arrowtail="onormal", dir="back"];
+        //ThreadFilling -> Algorithm;
+        Algorithm -> ThreadFilling[arrowtail="onormal", dir="back"];
         SimulatedAnnealing -> Algorithm;
         MaxDevicesPerThread -> Constraint;
         MaxDeviceDistance -> Constraint;
@@ -308,12 +308,12 @@ Does bucket filling.<BR ALIGN="TEXT"/>
 
     {rank="same";
         MaxDeviceDistance -> Constraint -> placeholder_1 -> Algorithm ->
-            BucketFilling [style="invis"];
+            ThreadFilling [style="invis"];
         rankdir="LR";
     }
 
     {edge[style="invis"];
-        BucketFilling -> SimulatedAnnealing;
+        ThreadFilling -> SimulatedAnnealing;
         MaxDeviceDistance -> MaxDevicesPerThread;
         Placer -> placeholder_1;
         placeholder_1 -> placeholder_2;

--- a/source/applications.md
+++ b/source/applications.md
@@ -1428,7 +1428,8 @@ Contains elements that instantiate every normal device in an application. If
 this section contains no children, no normal devices are instantiated (a
 supervisor device is still instantiated, though this is of questionable value
 outside debugging). The order of devices introduced in this section is
-preserved, which affects the result of bucket-filling placement.
+preserved, which affects the result of certain placement algorithms (thread
+filling and spreading).
 
 This element must occur exactly once in each `GraphInstance` section. No
 attributes are valid.

--- a/source/hardware_model.md
+++ b/source/hardware_model.md
@@ -208,9 +208,9 @@ serviced by the first mailbox in the first board (the origin thread), allow
    respective level of the hierarchy.
 
 ## Iteration Example
-In bucket-filling placement, devices are mapped to threads in order (like
-pouring water into a succession of buckets). This placement method must respect
-the constraint that core pairs can only contain the same type of device
+In thread-filling placement, devices are mapped to threads in order (like
+"pouring" devices into threads in succession). This placement method must
+respect the constraint that core pairs can only contain the same type of device
 (because their instruction memory spaces are shared).
 
 Without using `HardwareIterator`, this can be achieved through the following

--- a/source/placement_design.md
+++ b/source/placement_design.md
@@ -59,10 +59,10 @@ though many more may be contrived. With this in mind, the design requirements
  for the placement system in the Orchestrator are:
 
  - To support different algorithms, selectable at run time by the Orchestrator
-   operator. In early iterations, bucket filling and simulated annealing is
-   sufficient, but the design of the placement system should allow algorithms
-   to be added easily in future iterations to exploit properties specific to
-   the POETS placement problem (papers!).
+   operator. In early iterations, thread (bucket) filling and simulated
+   annealing is sufficient, but the design of the placement system should allow
+   algorithms to be added easily in future iterations to exploit properties
+   specific to the POETS placement problem (papers!).
 
  - To support run-time decisions about how the placement can be constrained,
    using a "walled-garden" set of constraints that can be
@@ -234,7 +234,7 @@ Possible constraints include (this is by no means an exhaustive list):
 Appendix D contains the list of supported constraints.
 
 ## Algorithms
-Algorithms represent "placement methods", like bucket filling, or simulated
+Algorithms represent "placement methods", like thread filling, or simulated
 annealing. Algorithms control the placement of devices in a given application
 onto the engine, without disrupting the placement of devices from other
 applications (recall that algorithms should act on one application and not be
@@ -298,7 +298,7 @@ in the POETS shell:
 
 ```
 POETS> placement /constraint = "MaxDevicesPerThread", 14
-POETS> placement /bucket = "APPLICATIONNAME"
+POETS> placement /tfill = "APPLICATIONNAME"
 POETS> placement /dump = "APPLICATIONNAME"
 ```
 
@@ -335,7 +335,7 @@ Operator commands, in more detail than in volume IV:
    completion of placement, along with the time taken.
 
    Appendix E contains the list of supported algorithms. `ALGORITHM` could be
-   "bucket", "sa" or something else that's implemented[^algorithmName]
+   "tfill", "sa" or something else that's implemented[^algorithmName]
 
 [^algorithmName]: Just don't call your algorithm "dump", or "place" (please).
 
@@ -479,7 +479,7 @@ test program!).
 ### Starting State
 "Random" placement is sufficient for this, but I suspect a "smart random"
 placement would be a better starting point - perhaps one which accounts for
-constraints. We could even use a bucket-fill placement as an initial state -
+constraints. We could even use a thread-filled placement as an initial state -
 it's cheap to compute.
 
 A point on random placement - core-pairs share instruction memory. As such, we
@@ -880,10 +880,9 @@ APPLICATIONNAME` operator command. All algorithms are aware of all constraints
 devices from other applications placed upon them. The available `ALGORITHM`s
 are:
 
- - `app`: See `bucket`.
+ - `app`: See `tfill`.
 
- - `bucket`: A bucket-filling placement, where the threads in the hardware
-   model are filled in sequence. This placement mechanism is device-type aware.
+ - `bucket`: See `tfill`.
 
  - `gc`: A gradientless climber implementation. Identical to `sa`, but with no
    disorder (so only superior solutions are accepted).
@@ -893,3 +892,6 @@ are:
    engine.
 
  - `sa`: The simulated annealing implementation described in section 5.
+
+ - `tfill`: A thread-filling placement, where the threads in the hardware model
+   are filled in sequence. This placement mechanism is device-type aware.

--- a/source/placement_design.md
+++ b/source/placement_design.md
@@ -887,6 +887,8 @@ are:
  - `gc`: A gradientless climber implementation. Identical to `sa`, but with no
    disorder (so only superior solutions are accepted).
 
+ - `link`: See `tfill`.
+
  - `rand`: A smart-random placement, which is constraint aware, and is aware of
    the placement of other applications. Places devices randomly across the
    engine.

--- a/source/user_guide.md
+++ b/source/user_guide.md
@@ -513,17 +513,17 @@ With a typelinked application graph instance (from XML), and a hardware graph
 map the former onto the latter. Command:
 
 ~~~ {.bash}
-place /bucket = *
+place /tfill = *
 ~~~
 
 The Orchestrator prints:
 
 ~~~ {.bash}
-POETS> 14:45:14.77: 309(I) Attempting to place graph instance 'test_ring_instance' using the 'buck' method...
+POETS> 14:45:14.77: 309(I) Attempting to place graph instance 'test_ring_instance' using the 'tfil' method...
 POETS> 14:45:14.77: 302(I) Graph instance 'test_ring_instance' placed successfully.
 ~~~
 
-This command invokes the bucket-filling algorithm in the placement system. Each
+This command invokes the thread-filling algorithm in the placement system. Each
 device defined in the application graph instance is one-to-many mapped to a
 thread in the POETS engine. For information about the placement performed,
 command:
@@ -618,7 +618,7 @@ Where the file `/absolute/path/to/batch/script` contains:
 ~~~ {.bash}
 load /app = +"ring_test.xml"
 tlink /app = *
-place /bucket = *
+place /tfill = *
 compose /app = *
 deploy /app = *
 initialise /app = *
@@ -770,10 +770,9 @@ Place commands operate on the placement subsystem of the Orchestrator, which is
 responsible for mapping applications to the compute hardware. See the placement
 documentation for a more detailed description of the commands that follow.
 
- - `placement /app`: Synonym for `placement \bucket`.
+ - `placement /app`: Synonym for `placement /tfill`.
 
- - `placement /bucket`: Given a typelinked application graph (or multiple),
-   places it onto the hardware by filling each thread in sequence.
+ - `placement /bucket`: Synonym for `placement /tfill`.
 
  - `placement /constraint`: Given a constraint type and a set of arguments,
    imposes a system-wide hard constraint onto future placed applications:
@@ -807,6 +806,9 @@ documentation for a more detailed description of the commands that follow.
    it using simulated annealing (with a random initial condition). The number
    of iterations can be defined at compile time (and will later be more easily
    configurable).
+
+ - `placement /tfill`: Given a typelinked application graph (or multiple),
+   places it onto the hardware by filling each thread in sequence.
 
  - `placement /unplace`: Given a typelinked application graph (or multiple),
    removes placement information for that application (effectively undoing a


### PR DESCRIPTION
Basically a text replacement. Also adds the `placement /tfill` command to the documentation. The `placement /bucket` command is retained for backwards compatibility.

When this PR, and it's partner in the Orchestrator, are both approved, I will make a new minor documentation release.