### PR TITLE
Update documents for Request Idle 

### DIFF
--- a/source/applications.md
+++ b/source/applications.md
@@ -946,7 +946,7 @@ attributed are valid.
 
 Contains code that reads the state of the device, determines whether any
 messages are to be sent, via the `RTS(x)` and `RTSSUP()` macros, and determines
-whether `OnDeviceIdle` should be called, via the `&requestIdle` bool. If multiple
+whether `OnDeviceIdle` should be called, via the `*requestIdle` bool. If multiple
 messages are to be sent, the order of their sending is undefined. Note that the
 state of the device cannot be modified in this block. Execution of this block
 is dependent on the softswitch used, though the default softswitch executes
@@ -980,7 +980,7 @@ attributes are valid.
 Contains code that is executed by the device when the softswitch is in the
 "idle" state. Under the default softswitch, this block is executed when no
 devices have any messages to receive or send and idle has been requested by
-setting `&requestIdle` to `true` in `ReadyToSend`. If the code in this block
+setting `*requestIdle` to `true` in `ReadyToSend`. If the code in this block
 returns a non-zero unsigned value, the code in the `ReadyToSend` section is 
 executed, which may result in the sending of messages.
 

--- a/source/applications.md
+++ b/source/applications.md
@@ -453,10 +453,12 @@ Device behaviours:
 
  - `OnIdle`: Invoked when there is nothing to receive, and nothing to send. The
    Softswitch will execute the `OnDeviceIdle` behaviour for each device it
-   manages in sequence, until either a packet can be received, or
-   `OnDeviceIdle` has been executed for all hosted devices. If any of the
-   `OnDeviceIdle` application-writer-supplied fragments returned a non-zero
-   unsigned value, that indicates the device may "want" to send a packet.
+   manages that has requested idle in its `ReadyToSend` handler, unless request
+   idle has been disabled. The Softswitch will iterate over its hosted devices
+   until either a packet can be received, or it has attempted to execute 
+   `OnDeviceIdle` for each device. If any of the `OnDeviceIdle` 
+   application-writer-supplied fragments returned a non-zero unsigned value,
+   that indicates the device may "want" to send a packet.
 
 #### Properties and State
 
@@ -942,8 +944,9 @@ attributed are valid.
 
 **Graphs/GraphType/DeviceTypes/DeviceType/ReadyToSend** (`:ReadyToSend:`)
 
-Contains code that reads the state of the device, and determines whether any
-messages are to be sent, via the `RTS(x)` and `RTSSUP()` macros. If multiple
+Contains code that reads the state of the device, determines whether any
+messages are to be sent, via the `RTS(x)` and `RTSSUP()` macros, and determines
+whether `OnDeviceIdle` should be called, via the `&requestIdle` bool. If multiple
 messages are to be sent, the order of their sending is undefined. Note that the
 state of the device cannot be modified in this block. Execution of this block
 is dependent on the softswitch used, though the default softswitch executes
@@ -976,9 +979,10 @@ attributes are valid.
 
 Contains code that is executed by the device when the softswitch is in the
 "idle" state. Under the default softswitch, this block is executed when no
-devices have any messages to receive or send. If the code in this block returns
-a non-zero unsigned value, the code in the `ReadyToSend` section is executed,
-which may result in the sending of messages.
+devices have any messages to receive or send and idle has been requested by
+setting `&requestIdle` to `true` in `ReadyToSend`. If the code in this block
+returns a non-zero unsigned value, the code in the `ReadyToSend` section is 
+executed, which may result in the sending of messages.
 
 This element must occur at most once in each `:DeviceType:` section. No
 attributes are valid.

--- a/source/user_guide.md
+++ b/source/user_guide.md
@@ -759,6 +759,12 @@ configured staging directory (`Output/Composer` in the default configuration).
  - `compose /nobuff`: Indicates that the Softswitches should be compiled in the 
    non-buffering mode (default).
 
+ - `compose /reqidle`: Indicates that the Softswitches should be compiled with the
+   Request Idle feature enabled. Refer to Volume III(B) for more information (default).
+
+ - `compose /noreqidle`: Indicates that the Softswitches should be compiled with the
+   Request Idle feature disabled.
+
  - `compose /logh`: Indicates that the Softswitches should be compiled with 
    the specified log handler. Options are `none` and `trivial` (default).
 


### PR DESCRIPTION
This pull request updates the documentation for the Request Idle behaviour detailed in https://github.com/POETSII/Orchestrator/issues/234. This is related to https://github.com/POETSII/Orchestrator/pull/274.

Vol III B has also been updated (changes are commented):[docx](https://github.com/POETSII/orchestrator-documentation/files/6754684/Orch_Vol_IIIB_Softswitches_Supervisor_and_Composer.docx)|[pdf](https://github.com/POETSII/orchestrator-documentation/files/6754686/Orch_Vol_IIIB_Softswitches_Supervisor_and_Composer.pdf)

When this PR is approved, I will update the PDF in Volumes on Development.