### PR TITLE
Mothership-facing documentation for hardware idle compatibility

### DIFF
--- a/source/mothership.md
+++ b/source/mothership.md
@@ -256,7 +256,7 @@ no other information about the application yet.
 |                 |    `distCount`        | unique distribution (`APP`,       |
 |                 | 2. `uint8_t`          | `DIST` and `APP`, `SUPD`)         |
 |                 |    `appNumber`        | messages in order to be fully     |
-|                 |                       | defined.                          |
+|                 | 3. `bool soloApp`     | defined.                          |
 +-----------------+-----------------------+-----------------------------------+
 | `APP`,  `DIST`  | 0. `std::string`      | Defines the properties for a      |
 |                 |    `appName`          | given core for a given            |

--- a/source/mothership.md
+++ b/source/mothership.md
@@ -242,6 +242,14 @@ no other information about the application yet.
 |                 |                       | down the Mothership process as    |
 |                 |                       | *quickly* as possible.            |
 +-----------------+-----------------------+-----------------------------------+
+| `APP`,  `EMPT`  | 0. `std::string`      | Loads all cores with instructions |
+|                 |    `codePath`         | and data from the same binaries.  |
+|                 | 1. `std::string`      | This is only used when the        |
+|                 |    `dataPath`         | Orchestrator is deploying an      |
+|                 |                       | application that uses hardware    |
+|                 |                       | level idle detection. This is not |
+|                 |                       | application-specific.             |
++-----------------+-----------------------+-----------------------------------+
 | `APP`,  `SPEC`  | 0. `std::string`      | Defines that an application on    |
 |                 |    `appName`          | the receiving Mothership process  |
 |                 | 1. `uint32_t`         | must have received `distCount`    |

--- a/source/mothership.md
+++ b/source/mothership.md
@@ -477,9 +477,12 @@ information. `AppInfo` is a class with these fields:
 
  - `std::string name`: The name of the application, redundant with the map key.
 
+ - `bool soloApp`: Defines how applications are loaded onto the hardware via
+   the backend. Defined by an (`APP`, `SPEC`) message.
+
  - `AppState state`: The state that the application is in. Table 3 shows how
-     C&C messages consumed by `MPICncResolver` drive application states. These
-     states are enumerated by `AppState` as:
+   C&C messages consumed by `MPICncResolver` drive application states. These
+   states are enumerated by `AppState` as:
 
     - `UNDERDEFINED`: The application has been partly sent to the Mothership
       process, but some cores have not been defined, or their binaries refer to


### PR DESCRIPTION
This changeset updates the Mothership documentation in line with the changes in https://github.com/POETSII/Orchestrator/pull/282.

Merge only when hardware idle itself has been merged into the Orchestrator's `development` branch (development currently in https://github.com/POETSII/Orchestrator/tree/FEATURE-0242-HardwareIdle).
